### PR TITLE
Avoid initial unzip errors

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -156,11 +156,11 @@ export async function downloadCoreLibrary() {
   if (process.platform === "win32") {
     await runCommand("tar", ["-xf", zipPath, "-C", cacheDir]);
   } else {
-    await runCommand("unzip", ["-q", zipPath, "-d", cacheDir]);
+    await runCommand("unzip", ["-o", "-q", zipPath, "-d", cacheDir]);
   }
 
   // Copy library
-  const libFile = `webui-2.${ext}`;
+  const libFile = `libwebui-2.${ext}`;
   await createDirectory(outputDir);
   await copyFileOverwrite(joinPath(cacheDir, fileName, libFile), joinPath(outputDir, libFile));
 


### PR DESCRIPTION
Hi!  In order for bun-webui to run on my Arch Linux system, I needed to apply the renamed library file:

```
const libFile = `libwebui-2.${ext}`;
```

I also needed to tell `unzip 6.0-22` to not stop using either `-o` (overwrite) or `-n` (no overwrite) as it was otherwise prompting for user interaction.

```
await runCommand("unzip", ["-o", "-q", zipPath, "-d", cacheDir]);
```

Thanks!