### PR TITLE
workaround for EACCESS / EPERM when bundled for single-file-executable

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,6 +3,7 @@
 
 import { promises as fs } from "fs";
 import { spawn } from "bun";
+import { homedir } from "os";
 
 // The WebUI core version to download
 const WebUICoreVersion = "2.5.0-beta.3";
@@ -85,8 +86,11 @@ export const currentModulePath = (() => {
 
   // hacky fix for EACCESS when being used in a single-file-executable in Bun
   if (directory.includes("$bunfs")) {
-    // Redirect to a fallback directory
-    directory = resolve(process.cwd(), "vfs");
+    // Redirect to a fallback directory'
+    directory = resolve(homedir(), ".bun-webui");
+    try {
+      createDirectory(directory)
+    } catch {/* it probably already exists. */ }
   }
 
   const pathSeparator = isWindows ? "\\" : "/";


### PR DESCRIPTION
When i was playing around with the library myself i constantly ran into errors like below when running it in a compiled single-file-executable.

```plaintext
permission denied, mkdir '/$bunfs'
    path: "/$bunfs",
 syscall: "mkdir",
   errno: -13,
    code: "EACCES"
)
```

It seems to be bacause of the way bun's virtual fs paths are returned - and it could def be fixed in a cleaner way, but this does work as a temporary workaround.

All it does is detect `$bunfs` in the function that returns the `currentModulePath` - and instead makes it fallback to `path.resolve(process.cwd(), "vfs")`

I've tested it myself, and it works in single-file-executables.

sysinfo in case it matters later, tested on:
Bun v1.3.6-canary.22+3898ed5e3 
Arch Linux x64 (Linux 6.17.7-zen)