### PR TITLE
Emit .js and .d.ts files for npm

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -21,7 +21,10 @@ jobs:
           registry-url: 'https://registry.npmjs.org/'
 
       - name: Install dependencies
-        run: echo "Bun-WebUI has no dependencies for now."
+        run: npm ci
+
+      - name: Build
+        run: npm run build
 
       - name: Publish to NPM
         run: npm publish --access public

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Dependencies
+node_modules
+
 # Bun binaries
 src/webui-windows-msvc-x64/
 src/webui-windows-msvc-arm/

--- a/.gitignore
+++ b/.gitignore
@@ -87,8 +87,11 @@ csx/
 
 # Python
 __pycache__/
-dist/
 webui2.egg-info/
+
+# TypeScript
+dist/
+tsconfig.tsbuildinfo
 
 # Rust
 target/

--- a/deps.ts
+++ b/deps.ts
@@ -1,11 +1,11 @@
 // Bun WebUI
-// Dependences needed by webui.ts
+// Dependences needed by webui.js
 
 import {
   fileExists,
   downloadCoreLibrary,
   currentModulePath,
-} from "./src/utils.ts";
+} from "./src/utils.js";
 
 /**
  * Determines the correct library filename based on the current operating system and CPU architecture.
@@ -13,7 +13,7 @@ import {
  *
  * @returns A promise that resolves to the path of the dynamic library.
  */
-async function getLibName() {
+export async function getLibName(): Promise<string> {
   let fileName = "";
   let localFileName = "";
 

--- a/mod.ts
+++ b/mod.ts
@@ -26,4 +26,4 @@
  * @module
  * @license MIT
  */
-export { WebUI } from "./src/webui.ts";
+export { WebUI } from "./src/webui.js";

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,61 @@
     "": {
       "name": "@webui-dev/bun-webui",
       "version": "2.5.4",
+      "license": "MIT",
+      "devDependencies": {
+        "@types/bun": "latest",
+        "typescript": "^5"
+      }
+    },
+    "node_modules/@types/bun": {
+      "version": "1.3.11",
+      "resolved": "https://registry.npmjs.org/@types/bun/-/bun-1.3.11.tgz",
+      "integrity": "sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bun-types": "1.3.11"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "25.5.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.0.tgz",
+      "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/bun-types": {
+      "version": "1.3.11",
+      "resolved": "https://registry.npmjs.org/bun-types/-/bun-types-1.3.11.tgz",
+      "integrity": "sha512-1KGPpoxQWl9f6wcZh57LvrPIInQMn2TQ7jsgxqpRzg+l0QPOFvJVH7HmvHo/AiPgwXy+/Thf6Ov3EdVn1vOabg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "dev": true,
       "license": "MIT"
     }
   }

--- a/package.json
+++ b/package.json
@@ -2,14 +2,21 @@
   "name": "@webui-dev/bun-webui",
   "version": "2.5.4",
   "description": "Use any web browser as GUI, with Bun in the backend and HTML5 in the frontend.",
-  "main": "mod.ts",
-  "directories": {
-    "example": "examples"
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/mod.d.ts",
+      "default": "./dist/mod.js"
+    }
   },
+  "files": [
+    "dist",
+    "src"
+  ],
   "scripts": {
     "typecheck": "tsc --noEmit",
     "build": "tsc -b",
-    "test": "echo \"Error: no test specified\" && exit 0"
+    "prepublishOnly": "bun run build"
   },
   "keywords": [
     "gui",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "scripts": {
     "typecheck": "tsc --noEmit",
     "build": "tsc -b",
-    "prepublishOnly": "bun run build"
+    "prepublishOnly": "npm run build"
   },
   "keywords": [
     "gui",

--- a/package.json
+++ b/package.json
@@ -7,9 +7,21 @@
     "example": "examples"
   },
   "scripts": {
+    "typecheck": "tsc --noEmit",
+    "build": "tsc -b",
     "test": "echo \"Error: no test specified\" && exit 0"
   },
-  "keywords": ["gui", "ui", "webui", "browser", "webview"],
+  "keywords": [
+    "gui",
+    "ui",
+    "webui",
+    "browser",
+    "webview"
+  ],
   "author": "Hassan Draga",
-  "license": "MIT"
+  "license": "MIT",
+  "devDependencies": {
+    "@types/bun": "latest",
+    "typescript": "^5"
+  }
 }

--- a/src/ffi_worker.ts
+++ b/src/ffi_worker.ts
@@ -9,8 +9,8 @@
 */
 
 import { JSCallback, type Pointer } from "bun:ffi";
-import { loadLib } from "./lib.ts";
-import { toCString } from "./utils.ts";
+import { loadLib } from "./lib.js";
+import { toCString } from "./utils.js";
 
 // Load the WebUI library inside the worker
 const _lib = loadLib();

--- a/src/ffi_worker.ts
+++ b/src/ffi_worker.ts
@@ -8,7 +8,7 @@
   Canada.
 */
 
-import { JSCallback } from "bun:ffi";
+import { JSCallback, type Pointer } from "bun:ffi";
 import { loadLib } from "./lib.ts";
 import { toCString } from "./utils.ts";
 
@@ -48,7 +48,7 @@ self.onmessage = (event: MessageEvent) => {
         args: ["usize", "usize", "pointer", "usize", "usize"],
         threadsafe: true,
       }
-    );
+    ) as any as Pointer;
     _lib.symbols.webui_interface_bind(windowId, toCString(elementId), callbackResource);
     self.postMessage({ id, result: "bind_success" });
   } else if (action === "setFileHandler") {
@@ -76,7 +76,7 @@ self.onmessage = (event: MessageEvent) => {
         args: ["pointer", "pointer"],
         threadsafe: true,
       }
-    );
+    ) as any as Pointer;
     _lib.symbols.webui_set_file_handler(windowId, callbackResource);
     self.postMessage({ id, result: "setFileHandler_success" });
   } else if (action === "setFileHandlerWindow") {
@@ -104,7 +104,7 @@ self.onmessage = (event: MessageEvent) => {
         args: ["usize", "pointer", "pointer"],
         threadsafe: true,
       }
-    );
+    ) as any as Pointer;
     _lib.symbols.webui_set_file_handler_window(windowId, callbackResource);
     self.postMessage({ id, result: "setFileHandlerWindow_success" });
   } else if (action === "setCloseHandlerWV") {
@@ -122,7 +122,7 @@ self.onmessage = (event: MessageEvent) => {
         args: ["usize"],
         threadsafe: true,
       }
-    );
+    ) as any as Pointer;
     _lib.symbols.webui_set_close_handler_wv(windowId, callbackResource);
     self.postMessage({ id, result: "setCloseHandlerWV_success" });
   } else if (action === "setLogger") {
@@ -148,7 +148,7 @@ self.onmessage = (event: MessageEvent) => {
         args: ["usize", "pointer", "pointer"],
         threadsafe: true,
       }
-    );
+    ) as any as Pointer;
     _lib.symbols.webui_set_logger(callbackResource, null);
     self.postMessage({ id, result: "setLogger_success" });
   }

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -1,8 +1,8 @@
 // Bun WebUI
-// FFI (Foreign Function Interface) for webui.ts
+// FFI (Foreign Function Interface) for webui.js
 
 import { dlopen } from "bun:ffi";
-import { libName } from "../deps.ts";
+import { libName } from "../deps.js";
 
 export function loadLib() {
   return dlopen(

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -1,7 +1,7 @@
 // Bun WebUI
 // FFI (Foreign Function Interface) for webui.ts
 
-import { dlopen, suffix } from "bun:ffi";
+import { dlopen } from "bun:ffi";
 import { libName } from "../deps.ts";
 
 export function loadLib() {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,5 @@
-import { WebUI } from "../mod.ts";
-import { loadLib } from "./lib.ts";
+import type { WebUI } from "../mod.js";
+import { loadLib } from "./lib.js";
 
 export type Usize = number | bigint;
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -5,6 +5,9 @@ import { promises as fs } from "fs";
 import { homedir } from "os";
 import { resolve } from "path";
 
+// The WebUI core version to download
+// const WebUICoreVersion = "2.5.0-beta.3";
+
 /**
  * Combine paths using the OS-specific separator.
  * Replaces multiple separators with a single one.
@@ -201,4 +204,4 @@ export function fromCString(value: Uint8Array): string {
   return new TextDecoder().decode(value.slice(0, end));
 }
 
-export class WebUIError extends Error {}
+export class WebUIError extends Error { }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -4,6 +4,7 @@
 import { promises as fs } from "fs";
 import { spawn } from "bun";
 import { homedir } from "os";
+import { resolve } from "path";
 
 // The WebUI core version to download
 const WebUICoreVersion = "2.5.0-beta.3";

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,12 +2,8 @@
 // Utilities
 
 import { promises as fs } from "fs";
-import { spawn } from "bun";
 import { homedir } from "os";
 import { resolve } from "path";
-
-// The WebUI core version to download
-const WebUICoreVersion = "2.5.0-beta.3";
 
 /**
  * Combine paths using the OS-specific separator.

--- a/src/webui.ts
+++ b/src/webui.ts
@@ -9,7 +9,7 @@
 */
 
 import { CString } from "bun:ffi";
-import { loadLib } from "./lib.ts";
+import { loadLib } from "./lib.js";
 import {
   BindCallback,
   BindFileHandlerCallback,
@@ -17,8 +17,8 @@ import {
   Usize,
   WebUIEvent,
   WebUILib,
-} from "./types.ts";
-import { fromCString, toCString, WebUIError } from "./utils.ts";
+} from "./types.js";
+import { fromCString, toCString, WebUIError } from "./utils.js";
 import type { Pointer } from "bun:ffi";
 
 function ptrToString(ptr: Pointer | null): string {
@@ -42,7 +42,7 @@ let _lib: WebUILib;
 //  [UserFunction] --> [Bind] --> [Worker] -> [WebUI]
 //  [WebUI] --> [Worker] --> [ffiWorker.onmessage] --> [UserFunction]
 
-const ffiWorker = new Worker(new URL("./ffi_worker.ts", import.meta.url).href, { type: "module" });
+const ffiWorker = new Worker(new URL("./ffi_worker.js", import.meta.url).href, { type: "module" });
 const pendingResponses = new Map<string, { resolve: (v: any) => void; reject: (e: any) => void }>();
 let callbackRegistry: BindCallback<any>[] = [];
 let callbackFileHandlerRegistry: BindFileHandlerCallback<any>[] = [];
@@ -81,10 +81,9 @@ ffiWorker.onmessage = async (event: MessageEvent) => {
           : Math.trunc(param_event_number);
 
       // Bind ID
-      const bind_id =
-        typeof param_bind_id === "bigint"
-          ? Number(param_bind_id)
-          : Math.trunc(param_bind_id);
+      void (typeof param_bind_id === "bigint"
+        ? Number(param_bind_id)
+        : Math.trunc(param_bind_id));
 
       // Arguments
       const args = {
@@ -129,7 +128,6 @@ ffiWorker.onmessage = async (event: MessageEvent) => {
       callbackIndex,
       windowId,
       param_url,
-      param_length
     } = data;
     const callbackFileHandlerFn = callbackFileHandlerRegistry[callbackIndex];
     if (typeof callbackFileHandlerFn !== "undefined") {
@@ -572,7 +570,7 @@ export class WebUI {
   }
 
   /**
-   * Choose between Bun and Node.js as runtime for .js and .ts files.
+   * Choose between Bun and Node.js as runtime for .js and .js files.
    */
   setRuntime(runtime: number): void {
     this.#lib.symbols.webui_set_runtime(BigInt(this.#window), BigInt(runtime));

--- a/src/webui.ts
+++ b/src/webui.ts
@@ -19,6 +19,15 @@ import {
   WebUILib,
 } from "./types.ts";
 import { fromCString, toCString, WebUIError } from "./utils.ts";
+import type { Pointer } from "bun:ffi";
+
+function ptrToString(ptr: Pointer | null): string {
+  return ptr ? new CString(ptr).toString() : "";
+}
+
+function ptrToNumber(ptr: Pointer | null): number {
+  return ptr ? Number(ptr) : 0;
+}
 
 // Register windows to bind instance to WebUI.Event
 const windows: Map<Usize, WebUI> = new Map();
@@ -67,10 +76,7 @@ ffiWorker.onmessage = async (event: MessageEvent) => {
           : Math.trunc(param_event_type);
 
       // Element
-      const element =
-        param_element !== null
-          ? new CString(param_element)
-          : "";
+      const element = ptrToString(param_element);
 
       // Event Number
       const event_number =
@@ -93,7 +99,7 @@ ffiWorker.onmessage = async (event: MessageEvent) => {
           return _lib.symbols.webui_interface_get_float_at(BigInt(win), BigInt(event_number), BigInt(index));
         },
         string: (index: number): string => {
-          return new CString(
+          return ptrToString(
             _lib.symbols.webui_interface_get_string_at(BigInt(win), BigInt(event_number), BigInt(index))
           );
         },
@@ -133,8 +139,7 @@ ffiWorker.onmessage = async (event: MessageEvent) => {
     if (typeof callbackFileHandlerFn !== "undefined") {
 
       // Get URL as string
-      const url_str :string = param_url !== null ?
-      new CString(param_url) : "";
+      const url_str = ptrToString(param_url);
 
       // Create URL Obj
       const url_obj :URL = new URL(url_str, "http://localhost");
@@ -149,7 +154,7 @@ ffiWorker.onmessage = async (event: MessageEvent) => {
       // WebUI uses it. Therefore, the solution is to create
       // a safe WebUI buffer through WebUI API. This WebUI
       // buffer will be automatically freed by WebUI later.
-      const webui_ptr :number = _lib.symbols.webui_malloc(BigInt(user_response.length));
+      const webui_ptr = _lib.symbols.webui_malloc(BigInt(user_response.length));
 
       // Copy data to C safe buffer
       if (typeof user_response === "string") {
@@ -180,11 +185,11 @@ ffiWorker.onmessage = async (event: MessageEvent) => {
       const win = windows.get(winId);
       if (!win) return;
 
-      const url_str: string = param_url !== null ? new CString(param_url) : "";
+      const url_str = ptrToString(param_url);
       const url_obj: URL = new URL(url_str, "http://localhost");
       const user_response: string | Uint8Array = await callbackFn(win, url_obj);
 
-      const webui_ptr: number = _lib.symbols.webui_malloc(BigInt(user_response.length));
+      const webui_ptr = _lib.symbols.webui_malloc(BigInt(user_response.length));
       if (typeof user_response === "string") {
         const cString = toCString(user_response);
         _lib.symbols.webui_memcpy(webui_ptr, cString, BigInt(cString.length));
@@ -523,7 +528,7 @@ export class WebUI {
    * Get the full current URL.
    */
   getUrl(): string {
-    return new CString(
+    return ptrToString(
       this.#lib.symbols.webui_get_url(BigInt(this.#window))
     );
   }
@@ -588,7 +593,7 @@ export class WebUI {
    * Start only the web server and return the URL. No window will be shown.
    */
   startServer(content: string): string {
-    return fromCString(
+    return ptrToString(
       this.#lib.symbols.webui_start_server(BigInt(this.#window), toCString(content))
     );
   }
@@ -888,7 +893,7 @@ export class WebUI {
    */
   static encode(str: string): string {
     WebUI.init();
-    return new CString(
+    return ptrToString(
       _lib.symbols.webui_encode(toCString(str))
     );
   }
@@ -898,7 +903,7 @@ export class WebUI {
    */
   static decode(str: string): string {
     WebUI.init();
-    return new CString(
+    return ptrToString(
       _lib.symbols.webui_decode(toCString(str))
     );
   }
@@ -964,7 +969,7 @@ export class WebUI {
    */
   static getMimeType(file: string): string {
     WebUI.init();
-    return new CString(_lib.symbols.webui_get_mime_type(toCString(file)));
+    return ptrToString(_lib.symbols.webui_get_mime_type(toCString(file)));
   }
 
   /**
@@ -1009,7 +1014,7 @@ export class WebUI {
    */
   static getLastErrorMessage(): string {
     WebUI.init();
-    return new CString(_lib.symbols.webui_get_last_error_message());
+    return ptrToString(_lib.symbols.webui_get_last_error_message());
   }
 
   static get version() {

--- a/src/webui.ts
+++ b/src/webui.ts
@@ -8,7 +8,7 @@
   Canada.
 */
 
-import { CString } from "bun:ffi";
+import { CString, type Pointer } from "bun:ffi";
 import { loadLib } from "./lib.js";
 import {
   BindCallback,
@@ -19,7 +19,6 @@ import {
   WebUILib,
 } from "./types.js";
 import { fromCString, toCString, WebUIError } from "./utils.js";
-import type { Pointer } from "bun:ffi";
 
 function ptrToString(ptr: Pointer | null): string {
   return ptr ? new CString(ptr).toString() : "";

--- a/src/webui.ts
+++ b/src/webui.ts
@@ -25,10 +25,6 @@ function ptrToString(ptr: Pointer | null): string {
   return ptr ? new CString(ptr).toString() : "";
 }
 
-function ptrToNumber(ptr: Pointer | null): number {
-  return ptr ? Number(ptr) : 0;
-}
-
 // Register windows to bind instance to WebUI.Event
 const windows: Map<Usize, WebUI> = new Map();
 
@@ -142,10 +138,10 @@ ffiWorker.onmessage = async (event: MessageEvent) => {
       const url_str = ptrToString(param_url);
 
       // Create URL Obj
-      const url_obj :URL = new URL(url_str, "http://localhost");
+      const url_obj: URL = new URL(url_str, "http://localhost");
 
       // Call the user callback
-      const user_response: string|Uint8Array = await callbackFileHandlerFn(url_obj);
+      const user_response: string | Uint8Array = await callbackFileHandlerFn(url_obj);
 
       // We can pass a local buffer to WebUI like this:
       // `return user_response;` However, this may create
@@ -208,7 +204,7 @@ ffiWorker.onmessage = async (event: MessageEvent) => {
     const callbackFn = callbackLoggerRegistry[callbackIndex];
     if (typeof callbackFn !== "undefined") {
       const level = typeof param_level === "bigint" ? Number(param_level) : Math.trunc(param_level);
-      const message = param_log !== null ? new CString(param_log).toString() : "";
+      const message = ptrToString(param_log);
       callbackFn(level, message);
     }
   } else if (id) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "lib": ["ESNext", "WebWorker"],
+    "target": "ESNext",
+    "module": "Preserve",
+    "moduleDetection": "force",
+    "allowJs": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "noPropertyAccessFromIndexSignature": false
+  },
+  "exclude": ["node_modules", "examples"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,10 +1,18 @@
 {
   "compilerOptions": {
+    // Language and Environment
     "lib": ["ESNext", "WebWorker"],
     "target": "ESNext",
+
+    // Module Resolution
     "module": "NodeNext",
     "moduleDetection": "force",
     "moduleResolution": "NodeNext",
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "forceConsistentCasingInFileNames": true,
+
+    // Strictness
     "strict": true,
     "skipLibCheck": true,
     "noFallthroughCasesInSwitch": true,
@@ -13,15 +21,16 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noPropertyAccessFromIndexSignature": false,
+
+    // Output
     "outDir": "./dist",
-    "tsBuildInfoFile": "./tsconfig.tsbuildinfo",
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,
     "removeComments": false,
-    "esModuleInterop": true,
-    "allowSyntheticDefaultImports": true,
-    "forceConsistentCasingInFileNames": true
+
+    // Build Performance
+    "tsBuildInfoFile": "./tsconfig.tsbuildinfo"
   },
   "include": ["src/**/*", "mod.ts", "deps.ts"],
   "exclude": ["node_modules", "dist", "examples"]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,19 +2,27 @@
   "compilerOptions": {
     "lib": ["ESNext", "WebWorker"],
     "target": "ESNext",
-    "module": "Preserve",
+    "module": "NodeNext",
     "moduleDetection": "force",
-    "allowJs": true,
-    "moduleResolution": "bundler",
-    "allowImportingTsExtensions": true,
+    "moduleResolution": "NodeNext",
     "strict": true,
     "skipLibCheck": true,
     "noFallthroughCasesInSwitch": true,
     "noUncheckedIndexedAccess": true,
     "noImplicitOverride": true,
-    "noUnusedLocals": false,
-    "noUnusedParameters": false,
-    "noPropertyAccessFromIndexSignature": false
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noPropertyAccessFromIndexSignature": false,
+    "outDir": "./dist",
+    "tsBuildInfoFile": "./tsconfig.tsbuildinfo",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "removeComments": false,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "forceConsistentCasingInFileNames": true
   },
-  "exclude": ["node_modules", "examples"]
+  "include": ["src/**/*", "mod.ts", "deps.ts"],
+  "exclude": ["node_modules", "dist", "examples"]
 }


### PR DESCRIPTION
npm modules in general should always publish js and dts files to npm instead of the source ts files. Even though bun works with ts files just fine, it created issues for other tools that assume that ts are source files.
For example typescipt will always type check ts files even if they are in node_modules, and the `skipLibCheck` option will have no effect.
In case of this library, running `tsc` by the user results in many errors being reported.
This PR adds a transpilation step before publishing to npm.
Also it fixes existing type errors in src/ without changing any of the logic.
Not sure if I missed anything, but I've checked it by linking locally and the library still works while the type errors are now gone.